### PR TITLE
Upgrade kots cli to 1.128.2

### DIFF
--- a/enterprise-infrastructure-examples/aws-cdk/README.md
+++ b/enterprise-infrastructure-examples/aws-cdk/README.md
@@ -270,6 +270,7 @@ If everything is set up correctly, you will be able to run `mysql -u$MYSQL_USER 
 | `wickr/alb:disableIpv6` | (Optional) Sets the ALB IP address type to IPv4. Default is dualstack | false |
 | `wickr/alb:privateAddress` | (Optional) Places the ALB in private subnets. Default is public subnets. Note: This does not change the ALB scheme to be internal. | false |
 | `wickr/enableCallingIngress` | Adds support for calling ingress via NLB | false |
+| `wickr/replicatedChannel` | (Optional) Override Replicated Channel | '' |
 
 ## Destroying Resources
 

--- a/enterprise-infrastructure-examples/aws-cdk/cdk.context.json
+++ b/enterprise-infrastructure-examples/aws-cdk/cdk.context.json
@@ -26,5 +26,6 @@
   "wickr/eks:clusterVersion": "1.30",
   "wickr/autoDeployWickr": true,
   "wickr/kms:kmsKey": null,
-  "wickr/enableCallingIngress": false
+  "wickr/enableCallingIngress": false,
+  "wickr/replicatedChannel": null
 }

--- a/enterprise-infrastructure-examples/aws-cdk/lib/stacks/kots.ts
+++ b/enterprise-infrastructure-examples/aws-cdk/lib/stacks/kots.ts
@@ -98,6 +98,7 @@ export class KotsStack extends Stack {
         KOTS_SECRET_NAME: secretName,
         LICENSE_BUCKET: this.licenseAsset.s3BucketName,
         LICENSE_KEY: this.licenseAsset.s3ObjectKey,
+        REPLICATED_CHANNEL: config.replicatedChannel,
         CA_BUCKET: this.caAsset.s3BucketName,
         CA_KEY: this.caAsset.s3ObjectKey,
         STACK_SUFFIX: config.stackSuffix,

--- a/enterprise-infrastructure-examples/aws-cdk/lib/types/wickr-environment-config.ts
+++ b/enterprise-infrastructure-examples/aws-cdk/lib/types/wickr-environment-config.ts
@@ -33,4 +33,5 @@ export interface IWickrEnvironmentConfig {
   autoDeployWickr: boolean
   importedKmsKeyArn: string
   enableCallingIngress: boolean
+  replicatedChannel: string
 }

--- a/enterprise-infrastructure-examples/aws-cdk/lib/util.ts
+++ b/enterprise-infrastructure-examples/aws-cdk/lib/util.ts
@@ -87,5 +87,6 @@ export function getEnvironmentConfig(app: App): IWickrEnvironmentConfig {
     autoDeployWickr: parseBoolean(app.node.tryGetContext('wickr/autoDeployWickr'), true),
     importedKmsKeyArn: app.node.tryGetContext('wickr/kms:kmsKey'),
     enableCallingIngress: app.node.tryGetContext('wickr/enableCallingIngress') || false,
+    replicatedChannel: app.node.tryGetContext('wickr/replicatedChannel') || '',
   }
 }


### PR DESCRIPTION
*Description of changes:*
- Upgrade kots cli to 1.128.2 in KotsInstallLambda
- Add `wickr/replicatedChannel` in cdk.context.json to override the default channel of the license

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
